### PR TITLE
Add gravatar_id field to User object

### DIFF
--- a/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/User.java
+++ b/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/User.java
@@ -57,6 +57,8 @@ public class User implements Serializable {
 
 	private int totalPrivateRepos;
 
+	private String gravatarId;
+
 	private String avatarUrl;
 
 	private String blog;
@@ -270,6 +272,22 @@ public class User implements Serializable {
 		this.totalPrivateRepos = totalPrivateRepos;
 		return this;
 	}
+
+	/**
+   	 * @return gravatarId
+   	 */
+   	public String getGravatarId() {
+   		return gravatarId;
+   	}
+
+   	/**
+   	 * @param gravatarId
+   	 * @return this user
+   	 */
+   	public User setGravatarId(String gravatarId) {
+   		this.gravatarId = gravatarId;
+   		return this;
+   	}
 
 	/**
 	 * @return avatarUrl


### PR DESCRIPTION
Hi @kevinsawicki, can we add this? I think gravatar_id is an 'official' field - it's documented at http://developer.github.com/v3/users/ with this example: "gravatar_id": "somehexcode"
