### PR TITLE
permissions object added to a repository

### DIFF
--- a/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/Permissions.java
+++ b/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/Permissions.java
@@ -1,4 +1,4 @@
-package jetbrains.charisma.persistent.globalSettings.org.eclipse.egit.github.core;
+package org.eclipse.egit.github.core;
 
 import java.io.Serializable;
 

--- a/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/Permissions.java
+++ b/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/Permissions.java
@@ -1,0 +1,45 @@
+package jetbrains.charisma.persistent.globalSettings.org.eclipse.egit.github.core;
+
+import java.io.Serializable;
+
+/**
+ * Repository permissions representation
+ */
+public class Permissions implements Serializable {
+
+	/** serialVersionUID */
+	private static final long serialVersionUID = -7716778137240559602L;
+
+	private boolean admin;
+
+	private boolean push;
+
+	private boolean pull;
+
+	public boolean isAdmin() {
+		return admin;
+	}
+
+	public Permissions setAdmin(boolean admin) {
+		this.admin = admin;
+		return this;
+	}
+
+	public boolean isPush() {
+		return push;
+	}
+
+	public Permissions setPush(boolean push) {
+		this.push = push;
+		return this;
+	}
+
+	public boolean isPull() {
+		return pull;
+	}
+
+	public Permissions setPull(boolean pull) {
+		this.pull = pull;
+		return this;
+	}
+}

--- a/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/Repository.java
+++ b/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/Repository.java
@@ -82,6 +82,8 @@ public class Repository implements IRepositoryIdProvider, Serializable {
 
 	private User owner;
 
+	private Permissions permissions;
+
 	/**
 	 * @return fork
 	 */
@@ -513,6 +515,22 @@ public class Repository implements IRepositoryIdProvider, Serializable {
 	 */
 	public Repository setOwner(User owner) {
 		this.owner = owner;
+		return this;
+	}
+
+	/**
+	 * @return permissions
+	 */
+	public Permissions getPermissions() {
+		return permissions;
+	}
+
+	/**
+	 * @param permissions
+	 * @return this repository
+	 */
+	public Repository setPermissions(Permissions permissions) {
+		this.permissions = permissions;
 		return this;
 	}
 


### PR DESCRIPTION
This nested permissions object is available in REST API response: https://developer.github.com/v3/repos/ for a repository. Just reflecting this in the library code.